### PR TITLE
Tweaks to enable build on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@
 # -ggdb -std=c99
 CFLAGS := -O3 -std=gnu99 -Wall -Werror -pedantic -Wextra -pthread ${CFLAGS}
 LDLIBS  = -lz -lpthread
+RM     ?= rm -f
 
-%.a: %.o
+.o.a:
 	strip -d -X $<
 	ar rvs $@ $<
 
@@ -13,7 +14,7 @@ all: gz-sort strip
 gz-sort: gz-sort.o
 
 strip: gz-sort
-	strip --strip-all $^
+	strip --strip-all gz-sort
 
 clean:
 	$(RM) *.o gz-sort

--- a/gz-sort.c
+++ b/gz-sort.c
@@ -8,15 +8,19 @@ compile: gcc -Wall -Os -o gz-sort gz-sort.c -lz
 */
 
 #define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
 #include <time.h>
 #include <unistd.h>
-#include <malloc.h>
 #include <pthread.h>
 #include <zlib.h>
+
+#ifdef __GNU_LIBRARY__
+#include <malloc.h>
+#endif
 
 #define CHUNK 16384
 #define LINE_START 1024
@@ -730,7 +734,10 @@ int main(int argc, char **argv)
     misc.label = "";
     misc.log_len = 0;
     misc.presort_bytes = PRESORT_WINDOW;
+
+#ifdef __GNU_LIBRARY__
     mallopt(M_MMAP_THRESHOLD, 1);
+#endif
 
     while ((optchar = getopt(argc, argv, "huTS:P:")) != -1)
     {

--- a/tests/_run-all.sh
+++ b/tests/_run-all.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 status=0
-while read script; do
+find ./tests -name '*.sh' ! -name '_*' | while read script; do
     $script || status=1
-done <<< "$(find ./tests -name '*.sh' ! -name '_*')"
+done
 
 exit $status
 


### PR DESCRIPTION
See commits for change details. Since gmake can also be installed in FreeBSD the Makefile changes aren't entirely necessary, but it removes gmake as a dependency.

The scripts still don't run since `md5sum` isn't available. I'm not sure how to make this more portable cleanly.